### PR TITLE
Fix dat clone credential preflight to honor selected AWS profile

### DIFF
--- a/src/dat.py
+++ b/src/dat.py
@@ -461,16 +461,23 @@ def dat_clone(bucket, folder, profile=None):
     err = 0
     if loc == "aws":
         # Verify that user is logged in
+        verify_cmd = ["aws", "sts", "get-caller-identity"]
+        if profile is not None:
+            verify_cmd.extend(["--profile", profile])
+
         try:
             subprocess.run(
-                'aws sts get-caller-identity',
+                verify_cmd,
                 stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
                 check=True,
-                shell=True
             )
-        except:
+        except subprocess.CalledProcessError as exc:
             err = 1
+            aws_error = exc.stderr.decode().strip()
             print("You are not currently logged into AWS")
+            if aws_error:
+                print(red(f"AWS error: {aws_error}"))
         if not err:
             cmd = "aws s3 sync s3://" + id + "/ " + folder + "/"
             if profile is not None:


### PR DESCRIPTION
### Motivation
- The AWS STS preflight check in `dat_clone` always used the default profile which could fail when the default profile uses a broken `credential_process` (producing errors like `main() got an unexpected keyword argument 'interactive'`).
- Improve error visibility so credential-resolution failures are easier to debug instead of showing only a generic "not logged in" message.

### Description
- Change the preflight invocation to build a command list `verify_cmd = ["aws","sts","get-caller-identity"]` and append `--profile` when `profile` is provided so the check honors the requested profile. 
- Replace the shell string call with `subprocess.run(verify_cmd, ..., check=True)` and handle `subprocess.CalledProcessError` rather than a broad `except` block. 
- Capture `stderr` from the AWS CLI call and print it (via `red(...)`) when present to surface credential-process/CLI errors for easier debugging.

### Testing
- Ran `python -m py_compile src/dat.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4fb6762608330a32655ecb6fbf26d)