### PR TITLE
Set up pytest + GitHub Actions with initial parity test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
+      - name: Run tests
+        run: pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,9 @@ build-backend = "setuptools.build_meta"
 
 [project.scripts]
 dat = "dat:dat"
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+]
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+import sys
+
+
+# Allow tests to import src/dat.py as module "dat" without installation.
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_manual_parity.py
+++ b/tests/test_manual_parity.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from dat import needs_push, read_inventory, read_config, take_inventory
+
+
+def test_needs_push_matches_existing_manual_test(monkeypatch):
+    """Automated parity test for the legacy tests/dat script's needs_push check."""
+    repo_root = Path(__file__).resolve().parents[1]
+    fixture_dir = repo_root / "tests" / "obj" / "1"
+
+    monkeypatch.chdir(fixture_dir)
+
+    config = read_config()
+    current = take_inventory(config)
+    local = read_inventory("../local.txt")
+
+    expected = ["a.txt", "c.txt", "d.txt", "g.txt", "h.txt", "j.txt", "k.txt"]
+    assert sorted(needs_push(current, local)) == expected


### PR DESCRIPTION
### Motivation
- Provide a minimal testing infrastructure so tests can be executed locally and in CI without converting the entire legacy manual suite.  
- Start with a low-risk parity test that mirrors an existing manual check to validate the setup before broader migration.  

### Description
- Add a GitHub Actions workflow at `.github/workflows/tests.yml` that checks out the repo, sets up Python, installs `pytest`, and runs `pytest`.  
- Add `tests/conftest.py` to prepend `src/` to `sys.path` so `src/dat.py` can be imported as the `dat` module in tests.  
- Add an initial automated parity test `tests/test_manual_parity.py` that reproduces the legacy `needs_push()` expectation from `tests/dat`.  
- Add an optional test dependency group in `pyproject.toml` (`[project.optional-dependencies].test`) that includes `pytest`.  

### Testing
- Ran `pytest -q` locally, which executed the new test and reported `1 passed` (with unrelated `docopt` syntax warnings).  
- The added workflow file is configured to run the same `pytest` steps on `push` and `pull_request` events in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5009c7c14833086818e6b803f89e2)